### PR TITLE
!Hotfix/#1 구글 인증 오류 해결 및 로그인 시 DB 유저 추가 구현

### DIFF
--- a/src/main/java/spring/beautiq/domain/auth/oauth2/config/SecurityConfig.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/config/SecurityConfig.java
@@ -1,16 +1,15 @@
 package spring.beautiq.domain.auth.oauth2.config;
 
-import io.jsonwebtoken.Jwt;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor; // Lombok
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -18,83 +17,58 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import spring.beautiq.domain.auth.oauth2.successhandler.CustomSuccessHandler;
 import spring.beautiq.domain.auth.oauth2.service.CustomOAuth2UserService;
 import spring.beautiq.global.jwt.JwtFilter;
-import spring.beautiq.global.jwt.JwtUtil;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private static final String FRONT_ORIGIN = "http://localhost:3000";
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomSuccessHandler customSuccessHandler;
-    private final JwtUtil jwtUtil;
-
-    public SecurityConfig(CustomOAuth2UserService customOAuth2UserService, CustomSuccessHandler customSuccessHandler,
-                          JwtUtil jwtUtil) {
-        this.customOAuth2UserService = customOAuth2UserService;
-        this.customSuccessHandler = customSuccessHandler;
-        this.jwtUtil = jwtUtil;
-    }
+    private final JwtFilter jwtFilter; // 컴포넌트 주입
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
-
-                //From 로그인 방식 disable
                 .formLogin(AbstractHttpConfigurer::disable)
-
-                //http basic 인증방식 disable
                 .httpBasic(AbstractHttpConfigurer::disable)
-
-                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
-
-                //경로별 인가 작업
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/", "/login", "/oauth2/authorization/**" ,"/success/", "/success/**", "/css/**", "/js/**","/getpostman.com/**", "/auth/**"
+                                "/", "/login", "/oauth2/authorization/**", "/success/**", "/css/**", "/js/**", "/getpostman.com/**", "/auth/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                //세션 설정(jwt=stateless 상태 필수)
-                .sessionManagement((session) -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-
-                .oauth2Login((oauth2) -> oauth2
-                        .userInfoEndpoint((userInfoEndpointConfig -> userInfoEndpointConfig
-                                .userService(customOAuth2UserService)))
-                        .successHandler(customSuccessHandler))
-
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                        .successHandler(customSuccessHandler)
+                )
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint((request, response, authException) -> {
-                            // 인증 실패시 redirect 말고 401 반환
                             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                             response.setContentType("application/json;charset=UTF-8");
                             response.getWriter().write("{\"error\": \"Unauthorized\"}");
                         })
                 )
-
-                .cors(corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
-                    @Override
-                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
-                        CorsConfiguration config = new CorsConfiguration();
-
-
-                        //프론트 주소
-                        config.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
-                        config.setAllowedMethods(Collections.singletonList("*"));
-                        config.setAllowCredentials(true);
-                        config.setAllowedHeaders(Collections.singletonList("*"));
-                        config.setMaxAge(3600L);
-
-                        config.setExposedHeaders(Collections.singletonList("Set-Cookie"));
-                        config.setExposedHeaders(Collections.singletonList("Authorization"));
-                        return config;
-
-                    }
-                }));
-
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()));
 
         return http.build();
+    }
+
+    private CorsConfigurationSource corsConfigurationSource() {
+        return (HttpServletRequest request) -> {
+            CorsConfiguration config = new CorsConfiguration();
+            config.setAllowedOrigins(List.of(FRONT_ORIGIN));
+            config.setAllowedMethods(List.of("*"));
+            config.setAllowCredentials(true);
+            config.setAllowedHeaders(List.of("*"));
+            config.setExposedHeaders(List.of("Set-Cookie", "Authorization"));
+            config.setMaxAge(3600L);
+            return config;
+        };
     }
 }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/dto/CustomOAuth2User.java
@@ -19,7 +19,6 @@ public class CustomOAuth2User implements OAuth2User {
     private Map<String, Object> buildAttributes(UserDTO dto) {
         Map<String, Object> map = new HashMap<>();
         if (dto.getId() != null) map.put("userId", dto.getId().toString());
-        if (dto.getAuthKey() != null) map.put("authKey", dto.getAuthKey());
         if (dto.getUsername() != null) map.put("username", dto.getUsername()); // 닉네임
         if (dto.getName() != null) map.put("name", dto.getName());
         if (dto.getRole() != null) map.put("role", dto.getRole());
@@ -40,8 +39,7 @@ public class CustomOAuth2User implements OAuth2User {
 
     @Override
     public String getName() {
-        // Spring Security principal 고유 식별자로 authKey 사용
-        if (userDTO.getAuthKey() != null) return userDTO.getAuthKey();
+        // Spring Security principal 고유 식별자로 userId 사용
         if (userDTO.getId() != null) return userDTO.getId().toString();
         return "anonymous";
     }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/dto/CustomOAuth2User.java
@@ -1,10 +1,6 @@
 package spring.beautiq.domain.auth.oauth2.dto;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import org.hibernate.type.descriptor.jdbc.OracleJsonBlobJdbcType;
+import java.util.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -12,37 +8,41 @@ import spring.beautiq.domain.user.dto.UserDTO;
 
 public class CustomOAuth2User implements OAuth2User {
 
-
     private final UserDTO userDTO;
+    private final Map<String, Object> attributes; // 캐시된 attribute
 
     public CustomOAuth2User(UserDTO userDTO) {
         this.userDTO = userDTO;
+        this.attributes = buildAttributes(userDTO);
+    }
+
+    private Map<String, Object> buildAttributes(UserDTO dto) {
+        Map<String, Object> map = new HashMap<>();
+        if (dto.getId() != null) map.put("userId", dto.getId().toString());
+        if (dto.getAuthKey() != null) map.put("authKey", dto.getAuthKey());
+        if (dto.getUsername() != null) map.put("username", dto.getUsername()); // 닉네임
+        if (dto.getName() != null) map.put("name", dto.getName());
+        if (dto.getRole() != null) map.put("role", dto.getRole());
+        if (dto.getEmail() != null) map.put("email", dto.getEmail());
+        return Collections.unmodifiableMap(map);
     }
 
     @Override
     public Map<String, Object> getAttributes() {
-        return Map.of(
-                "username", userDTO.getUsername(),
-                "name", userDTO.getName(),
-                "role", userDTO.getRole()
-        );
+        return attributes;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(userDTO.getRole()));
+        String role = userDTO.getRole() == null ? "ROLE_USER" : userDTO.getRole();
+        return List.of(new SimpleGrantedAuthority(role));
     }
-
-
 
     @Override
     public String getName() {
-        return userDTO.getName();
+        // Spring Security principal 고유 식별자로 authKey 사용
+        if (userDTO.getAuthKey() != null) return userDTO.getAuthKey();
+        if (userDTO.getId() != null) return userDTO.getId().toString();
+        return "anonymous";
     }
-
-    public String getUsername() {
-        return userDTO.getUsername();
-    }
-
-
 }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOAuth2UserService.java
@@ -15,42 +15,43 @@ import spring.beautiq.domain.auth.oauth2.dto.KakaoResponse;
 import spring.beautiq.domain.auth.oauth2.dto.OAuth2Response;
 import spring.beautiq.domain.user.dto.UserDTO;
 import spring.beautiq.domain.user.entity.UserEntity;
-import spring.beautiq.domain.user.repository.UserRepository;
+import spring.beautiq.domain.user.service.UserAuthService;
+import spring.beautiq.global.exception.ApiException;
+import spring.beautiq.global.exception.GlobalErrorCode;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-    private final UserRepository userRepository;
-
+    private final UserAuthService userAuthService;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-
-        OAuth2User oAuth2User = super.loadUser(userRequest);
-
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        try {
+            OAuth2User rawUser = super.loadUser(userRequest);
 
-        OAuth2Response oAuth2Response = null;
-        if (registrationId.equals("google")) {
-            oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+            OAuth2Response oAuth2Response = switch (registrationId) {
+                case "google" -> new GoogleResponse(rawUser.getAttributes());
+                case "kakao" -> new KakaoResponse(rawUser.getAttributes());
+                default -> throw GlobalErrorCode.OAUTH_UNSUPPORTED_PROVIDER.toException();
+            };
 
-        } else if (registrationId.equals("kakao")) {
-            oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
-        } else {
-            throw new OAuth2AuthenticationException("지원하지 않는 provider: " + registrationId);
+            UserEntity user = userAuthService.upsert(
+                    oAuth2Response.getProvider(),
+                    oAuth2Response.getProviderId(),
+                    oAuth2Response.getName(),
+                    oAuth2Response.getEmail(),
+                    "ROLE_USER"
+            );
+
+            return new CustomOAuth2User(UserDTO.from(user));
+        } catch (ApiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ApiException(GlobalErrorCode.OAUTH_USER_INFO_LOAD_FAILED, e);
         }
-
-
-        String username = oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
-
-            UserDTO userDTO = new UserDTO();
-            userDTO.setUsername(username);
-            userDTO.setName(oAuth2Response.getName());
-            userDTO.setRole("ROLE_USER");
-
-            return new CustomOAuth2User(userDTO);
-        }
+    }
 
 }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOidcUserService.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOidcUserService.java
@@ -1,0 +1,16 @@
+package spring.beautiq.domain.auth.oauth2.service;
+
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOidcUserService extends OidcUserService {
+
+    // 단순히 기본 동작 유지 (Google OIDC는 SuccessHandler에서 처리)
+    @Override
+    public OidcUser loadUser(OidcUserRequest userRequest) {
+        return super.loadUser(userRequest);
+    }
+}

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/successhandler/CustomSuccessHandler.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/successhandler/CustomSuccessHandler.java
@@ -5,54 +5,71 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor; // 추가
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import spring.beautiq.domain.auth.oauth2.dto.CustomOAuth2User;
+import spring.beautiq.domain.user.entity.UserEntity;
+import spring.beautiq.domain.user.service.UserAuthService; // 공통 upsert 서비스
 import spring.beautiq.global.jwt.JwtUtil;
 
 @Component
+@RequiredArgsConstructor
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JwtUtil jwtUtil;
+    private static final long TOKEN_EXPIRE_HOURS = 60L; // 60시간
+    private static final int COOKIE_MAX_AGE_SEC = 60 * 30; // 30분
+    private static final String REDIRECT_SUCCESS = "http://localhost:8080/success";
 
-    public CustomSuccessHandler(JwtUtil jwtUtil) {
-        this.jwtUtil = jwtUtil;
-    }
+    private final JwtUtil jwtUtil;
+    private final UserAuthService userAuthService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        Object principal = authentication.getPrincipal();
 
-        //OAuth2User
-        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+        String role = firstAuthority(authentication);
+        String authKey;
 
-        String username = customUserDetails.getUsername();
+        if (principal instanceof OidcUser oidcUser) { // Google OIDC
+            UserEntity user = userAuthService.upsert(
+                    "google",
+                    oidcUser.getSubject(),
+                    safeName(oidcUser),
+                    oidcUser.getEmail(),
+                    role
+            );
+            authKey = user.getAuthKey();
+        } else { // CustomOAuth2User (Kakao 등)
+            authKey = authentication.getName();
+        }
 
-        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
-        GrantedAuthority authority = iterator.next();
-        String role = authority.getAuthority();
-
-        String token = jwtUtil.createJwt(username, role, java.util.concurrent.TimeUnit.HOURS.toMillis(60));
-
-        response.addCookie(createCookie("Authorization", token));
-
-        // 프론트 측 특정 리다이렉트 url
-        response.sendRedirect("http://localhost:8080/success");
-
+        String token = jwtUtil.createJwt(authKey, role, TimeUnit.HOURS.toMillis(TOKEN_EXPIRE_HOURS));
+        response.addCookie(cookie(token));
+        response.sendRedirect(REDIRECT_SUCCESS);
     }
 
-
-
-    private Cookie createCookie(String key, String value) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(60*30);
-        cookie.setPath("/");
-        cookie.setHttpOnly(false);
-
-        return cookie;
+    private String safeName(OidcUser user) {
+        String full = user.getFullName();
+        if (full != null && !full.isBlank()) return full;
+        String attr = user.getAttribute("name");
+        return attr != null ? attr : "USER";
     }
 
+    private String firstAuthority(Authentication auth) {
+        Collection<? extends GrantedAuthority> authorities = auth.getAuthorities();
+        if (authorities == null || authorities.isEmpty()) return "ROLE_USER";
+        return authorities.iterator().next().getAuthority();
+    }
+
+    private Cookie cookie(String value) {
+        Cookie c = new Cookie("Authorization", value);
+        c.setMaxAge(COOKIE_MAX_AGE_SEC);
+        c.setPath("/");
+        c.setHttpOnly(false); // 정책 유지
+        return c;
+    }
 }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/successhandler/CustomSuccessHandler.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/successhandler/CustomSuccessHandler.java
@@ -6,15 +6,15 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
-import lombok.RequiredArgsConstructor; // 추가
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import spring.beautiq.domain.user.entity.UserEntity;
-import spring.beautiq.domain.user.service.UserAuthService; // 공통 upsert 서비스
+import spring.beautiq.domain.auth.oauth2.dto.CustomOAuth2User;
 import spring.beautiq.global.jwt.JwtUtil;
+
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -25,38 +25,22 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private static final String REDIRECT_SUCCESS = "http://localhost:8080/success";
 
     private final JwtUtil jwtUtil;
-    private final UserAuthService userAuthService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         Object principal = authentication.getPrincipal();
 
-        String role = firstAuthority(authentication);
-        String authKey;
-
-        if (principal instanceof OidcUser oidcUser) { // Google OIDC
-            UserEntity user = userAuthService.upsert(
-                    "google",
-                    oidcUser.getSubject(),
-                    safeName(oidcUser),
-                    oidcUser.getEmail(),
-                    role
-            );
-            authKey = user.getAuthKey();
-        } else { // CustomOAuth2User (Kakao 등)
-            authKey = authentication.getName();
+        if (!(principal instanceof CustomOAuth2User customUser)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid authentication principal");
+            return;
         }
 
-        String token = jwtUtil.createJwt(authKey, role, TimeUnit.HOURS.toMillis(TOKEN_EXPIRE_HOURS));
+        String role = firstAuthority(authentication);
+        UUID userId = UUID.fromString(customUser.getName()); // getName()은 userId를 반환
+
+        String token = jwtUtil.createJwt(userId, role, TimeUnit.HOURS.toMillis(TOKEN_EXPIRE_HOURS));
         response.addCookie(cookie(token));
         response.sendRedirect(REDIRECT_SUCCESS);
-    }
-
-    private String safeName(OidcUser user) {
-        String full = user.getFullName();
-        if (full != null && !full.isBlank()) return full;
-        String attr = user.getAttribute("name");
-        return attr != null ? attr : "USER";
     }
 
     private String firstAuthority(Authentication auth) {
@@ -69,7 +53,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         Cookie c = new Cookie("Authorization", value);
         c.setMaxAge(COOKIE_MAX_AGE_SEC);
         c.setPath("/");
-        c.setHttpOnly(false); // 정책 유지
+        c.setHttpOnly(true);
+        c.setSecure(true);
+        c.setAttribute("SameSite", "None");
         return c;
     }
 }

--- a/src/main/java/spring/beautiq/domain/user/dto/UserDTO.java
+++ b/src/main/java/spring/beautiq/domain/user/dto/UserDTO.java
@@ -14,23 +14,20 @@ import spring.beautiq.domain.user.entity.UserEntity;
 @ToString
 public class UserDTO {
 
-    private UUID id; // 신규 추가: 저장된 사용자 식별자
+    private UUID id; // 사용자 식별자
 
     private String role;
 
     private String name;
 
-    private String authKey; // 추가: provider_providerId 내부 키
-
     private String username; // 닉네임(표시용)
 
-    private String email; // 신규 추가: 이메일(있을 경우)
+    private String email; // 이메일(있을 경우)
 
     public static UserDTO from(UserEntity entity) {
         if (entity == null) return null;
         return UserDTO.builder()
                 .id(entity.getId())
-                .authKey(entity.getAuthKey())
                 .username(entity.getUsername())
                 .name(entity.getName())
                 .role(entity.getRole())

--- a/src/main/java/spring/beautiq/domain/user/dto/UserDTO.java
+++ b/src/main/java/spring/beautiq/domain/user/dto/UserDTO.java
@@ -1,16 +1,40 @@
 package spring.beautiq.domain.user.dto;
 
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
+
+import java.util.UUID;
+import spring.beautiq.domain.user.entity.UserEntity;
 
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class UserDTO {
+
+    private UUID id; // 신규 추가: 저장된 사용자 식별자
 
     private String role;
 
     private String name;
 
-    private String username;
+    private String authKey; // 추가: provider_providerId 내부 키
+
+    private String username; // 닉네임(표시용)
+
+    private String email; // 신규 추가: 이메일(있을 경우)
+
+    public static UserDTO from(UserEntity entity) {
+        if (entity == null) return null;
+        return UserDTO.builder()
+                .id(entity.getId())
+                .authKey(entity.getAuthKey())
+                .username(entity.getUsername())
+                .name(entity.getName())
+                .role(entity.getRole())
+                .email(entity.getEmail())
+                .build();
+    }
 }

--- a/src/main/java/spring/beautiq/domain/user/entity/UserEntity.java
+++ b/src/main/java/spring/beautiq/domain/user/entity/UserEntity.java
@@ -2,18 +2,9 @@ package spring.beautiq.domain.user.entity;
 
 
 import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import java.util.Set;
-
-import java.util.UUID;
-import lombok.*;
+import lombok.Getter;
+import lombok.Setter;
 import spring.beautiq.global.base.BaseEntity;
 
 @Entity
@@ -21,14 +12,10 @@ import spring.beautiq.global.base.BaseEntity;
 @Setter
 public class UserEntity extends BaseEntity {
 
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    @Column(name = "auth_key", unique = true, nullable = false)
+    private String authKey; // 기존 username -> authKey (provider_providerId)
+    private String username;
     private String email;
     private String name;
-    private String username;
     private String role;
-
 }
-

--- a/src/main/java/spring/beautiq/domain/user/entity/UserEntity.java
+++ b/src/main/java/spring/beautiq/domain/user/entity/UserEntity.java
@@ -1,21 +1,37 @@
 package spring.beautiq.domain.user.entity;
 
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
 import lombok.Getter;
 import lombok.Setter;
 import spring.beautiq.global.base.BaseEntity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @Setter
 public class UserEntity extends BaseEntity {
 
-    @Column(name = "auth_key", unique = true, nullable = false)
-    private String authKey; // 기존 username -> authKey (provider_providerId)
-    private String username;
-    private String email;
-    private String name;
+    @Column(length = 50)
+    private String username; // 닉네임, 변경 가능
+
+    @Column(length = 100)
+    private String email; // 소셜마다 다를 수 있으므로 nullable
+
+    @Column(length = 50)
+    private String name; // 실명
+
+    @Column(length = 20)
     private String role;
+
+    private LocalDateTime lastLoginAt;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserProviderEntity> providers = new ArrayList<>();
 }

--- a/src/main/java/spring/beautiq/domain/user/entity/UserProviderEntity.java
+++ b/src/main/java/spring/beautiq/domain/user/entity/UserProviderEntity.java
@@ -1,0 +1,29 @@
+package spring.beautiq.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import spring.beautiq.global.base.BaseEntity;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@Table(
+    name = "user_provider",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_id"})
+)
+public class UserProviderEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @Column(nullable = false, length = 50)
+    private String provider; // google, kakao 등
+
+    @Column(name = "provider_id", nullable = false, length = 100)
+    private String providerId; // 소셜에서 발급한 고유 ID
+}
+

--- a/src/main/java/spring/beautiq/domain/user/repository/UserProviderRepository.java
+++ b/src/main/java/spring/beautiq/domain/user/repository/UserProviderRepository.java
@@ -1,0 +1,18 @@
+package spring.beautiq.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import spring.beautiq.domain.user.entity.UserProviderEntity;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserProviderRepository extends JpaRepository<UserProviderEntity, Long> {
+
+    Optional<UserProviderEntity> findByProviderAndProviderId(String provider, String providerId);
+
+    List<UserProviderEntity> findByUserId(UUID userId);
+
+    boolean existsByProviderAndProviderId(String provider, String providerId);
+}
+

--- a/src/main/java/spring/beautiq/domain/user/repository/UserRepository.java
+++ b/src/main/java/spring/beautiq/domain/user/repository/UserRepository.java
@@ -1,12 +1,11 @@
 package spring.beautiq.domain.user.repository;
 
 
-import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import spring.beautiq.domain.user.entity.UserEntity;
 
 public interface UserRepository extends JpaRepository<UserEntity, UUID> {
-    UserEntity findByUsername(String username);
+    UserEntity findByAuthKey(String authKey);
 }

--- a/src/main/java/spring/beautiq/domain/user/repository/UserRepository.java
+++ b/src/main/java/spring/beautiq/domain/user/repository/UserRepository.java
@@ -1,11 +1,12 @@
 package spring.beautiq.domain.user.repository;
 
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import spring.beautiq.domain.user.entity.UserEntity;
 
 public interface UserRepository extends JpaRepository<UserEntity, UUID> {
-    UserEntity findByAuthKey(String authKey);
+    Optional<UserEntity> findByEmail(String email);
 }

--- a/src/main/java/spring/beautiq/domain/user/service/UserAuthService.java
+++ b/src/main/java/spring/beautiq/domain/user/service/UserAuthService.java
@@ -1,0 +1,52 @@
+package spring.beautiq.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import spring.beautiq.domain.user.entity.UserEntity;
+import spring.beautiq.domain.user.repository.UserRepository;
+
+/**
+ * OAuth2 / OIDC 로그인 시 사용자 생성 또는 변경(동기화) 중복 로직을 캡슐화.
+ * 기능상 변화 없이 공통화 & 가독성 향상 목적.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserAuthService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * provider, providerId로 authKey를 구성하여 사용자 upsert.
+     * - 신규면 생성 (username 닉네임 초기값 name 값 사용)
+     * - 기존이면 name/email 변경 시만 update
+     * @param provider    (google, kakao 등)
+     * @param providerId  소셜 프로바이더가 주는 고유 subject/id
+     * @param name        표시 이름
+     * @param email       이메일(없을 수도 있음)
+     * @param role        권한(default ROLE_USER)
+     * @return 저장/업데이트 된 UserEntity
+     */
+    public UserEntity upsert(String provider, String providerId, String name, String email, String role) {
+        String authKey = provider + "_" + providerId;
+        UserEntity user = userRepository.findByAuthKey(authKey);
+        if (user == null) {
+            user = new UserEntity();
+            user.setAuthKey(authKey);
+            user.setRole(role);
+            user.setName(name);
+            user.setEmail(email);
+            user.setUsername(name); // 닉네임 초기값
+            return userRepository.save(user);
+        }
+        boolean changed = false;
+        if (name != null && !name.equals(user.getName())) { user.setName(name); changed = true; }
+        if (email != null && !email.equals(user.getEmail())) { user.setEmail(email); changed = true; }
+        if (changed) {
+            user = userRepository.save(user);
+        }
+        return user;
+    }
+}
+

--- a/src/main/java/spring/beautiq/domain/user/service/UserAuthService.java
+++ b/src/main/java/spring/beautiq/domain/user/service/UserAuthService.java
@@ -4,11 +4,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.beautiq.domain.user.entity.UserEntity;
+import spring.beautiq.domain.user.entity.UserProviderEntity;
+import spring.beautiq.domain.user.repository.UserProviderRepository;
 import spring.beautiq.domain.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 /**
  * OAuth2 / OIDC 로그인 시 사용자 생성 또는 변경(동기화) 중복 로직을 캡슐화.
- * 기능상 변화 없이 공통화 & 가독성 향상 목적.
+ * - 한 계정에 여러 소셜 계정 연동 지원 (email 기반 통합)
+ * - provider + providerId 조합으로 UserProvider 관리
  */
 @Service
 @RequiredArgsConstructor
@@ -16,11 +22,18 @@ import spring.beautiq.domain.user.repository.UserRepository;
 public class UserAuthService {
 
     private final UserRepository userRepository;
+    private final UserProviderRepository userProviderRepository;
 
     /**
-     * provider, providerId로 authKey를 구성하여 사용자 upsert.
-     * - 신규면 생성 (username 닉네임 초기값 name 값 사용)
-     * - 기존이면 name/email 변경 시만 update
+     * provider, providerId로 사용자 upsert.
+     *
+     * 로직:
+     * 1. provider + providerId로 기존 UserProvider 조회
+     * 2. 있으면 해당 User 반환 (정보 업데이트)
+     * 3. 없으면:
+     *    - email이 있고, 해당 email의 User가 있으면 → 기존 User에 새 Provider 추가 (계정 통합)
+     *    - 없으면 → 새 User + Provider 생성
+     *
      * @param provider    (google, kakao 등)
      * @param providerId  소셜 프로바이더가 주는 고유 subject/id
      * @param name        표시 이름
@@ -29,24 +42,55 @@ public class UserAuthService {
      * @return 저장/업데이트 된 UserEntity
      */
     public UserEntity upsert(String provider, String providerId, String name, String email, String role) {
-        String authKey = provider + "_" + providerId;
-        UserEntity user = userRepository.findByAuthKey(authKey);
-        if (user == null) {
-            user = new UserEntity();
-            user.setAuthKey(authKey);
-            user.setRole(role);
-            user.setName(name);
-            user.setEmail(email);
-            user.setUsername(name); // 닉네임 초기값
+        // 1. 기존 Provider 조회
+        Optional<UserProviderEntity> existingProvider = userProviderRepository.findByProviderAndProviderId(provider, providerId);
+
+        if (existingProvider.isPresent()) {
+            // 기존 소셜 계정으로 로그인 → User 정보 업데이트
+            UserEntity user = existingProvider.get().getUser();
+            updateUserInfo(user, name, email);
+            user.setLastLoginAt(LocalDateTime.now());
             return userRepository.save(user);
         }
-        boolean changed = false;
-        if (name != null && !name.equals(user.getName())) { user.setName(name); changed = true; }
-        if (email != null && !email.equals(user.getEmail())) { user.setEmail(email); changed = true; }
-        if (changed) {
+
+        // 2. 새 소셜 계정 로그인 → email 기반 계정 통합 시도
+        UserEntity user = null;
+        if (email != null && !email.isBlank()) {
+            user = userRepository.findByEmail(email).orElse(null);
+        }
+
+        if (user == null) {
+            // 3. 신규 User 생성
+            user = new UserEntity();
+            user.setRole(role != null ? role : "ROLE_USER");
+            user.setName(name);
+            user.setEmail(email);
+            user.setUsername(name != null ? name : "USER"); // 닉네임 초기값
+            user.setLastLoginAt(LocalDateTime.now());
+            user = userRepository.save(user);
+        } else {
+            // 4. 기존 User에 새 Provider 연동
+            updateUserInfo(user, name, email);
+            user.setLastLoginAt(LocalDateTime.now());
             user = userRepository.save(user);
         }
+
+        // 5. 새 Provider 추가
+        UserProviderEntity newProvider = new UserProviderEntity();
+        newProvider.setUser(user);
+        newProvider.setProvider(provider);
+        newProvider.setProviderId(providerId);
+        userProviderRepository.save(newProvider);
+
         return user;
     }
-}
 
+    private void updateUserInfo(UserEntity user, String name, String email) {
+        if (name != null && !name.equals(user.getName())) {
+            user.setName(name);
+        }
+        if (email != null && !email.equals(user.getEmail())) {
+            user.setEmail(email);
+        }
+    }
+}

--- a/src/main/java/spring/beautiq/global/exception/GlobalErrorCode.java
+++ b/src/main/java/spring/beautiq/global/exception/GlobalErrorCode.java
@@ -12,7 +12,9 @@ public enum GlobalErrorCode implements ErrorCode {
     INVALID_ACCESS_TOKEN("유효하지 않은 액세스 토큰입니다.", HttpStatus.BAD_REQUEST),
     FILE_UPLOAD_FAILED("파일 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_EXPIRED_JWT("토큰이 만료되었거나 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_JWT("유효하지 않은 JWT입니다.", HttpStatus.UNAUTHORIZED);
+    INVALID_JWT("유효하지 않은 JWT입니다.", HttpStatus.UNAUTHORIZED),
+    OAUTH_UNSUPPORTED_PROVIDER("지원하지 않는 OAuth2 Provider 입니다.", HttpStatus.BAD_REQUEST),
+    OAUTH_USER_INFO_LOAD_FAILED("OAuth2 사용자 정보 조회에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
     private final String message;
     private final HttpStatus httpStatus;
 

--- a/src/main/java/spring/beautiq/global/jwt/JwtFilter.java
+++ b/src/main/java/spring/beautiq/global/jwt/JwtFilter.java
@@ -10,7 +10,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
-import lombok.RequiredArgsConstructor; // Lombok
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -86,11 +87,21 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private Optional<UsernamePasswordAuthenticationToken> buildAuthentication(String token) {
         try {
-            String authKey = jwtUtil.getUsername(token);
+            UUID userId = jwtUtil.getUserId(token);
             String role = jwtUtil.getRole(token);
-            UserEntity user = userRepository.findByAuthKey(authKey);
+
+            UserEntity user = userRepository.findById(userId).orElse(null);
+            if (user == null) {
+                // 사용자가 삭제되거나 존재하지 않으면 인증 실패
+                return Optional.empty();
+            }
+
             UserDTO dto = UserDTO.from(user);
-            if (dto == null) { dto = new UserDTO(); dto.setAuthKey(authKey); dto.setRole(role); }
+            if (dto == null) {
+                // DTO 변환 실패 시에도 인증 실패
+                return Optional.empty();
+            }
+
             CustomOAuth2User principal = new CustomOAuth2User(dto);
             return Optional.of(new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
         } catch (Exception e) {

--- a/src/main/java/spring/beautiq/global/jwt/JwtFilter.java
+++ b/src/main/java/spring/beautiq/global/jwt/JwtFilter.java
@@ -1,94 +1,111 @@
 package spring.beautiq.global.jwt;
 
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor; // Lombok
+import org.springframework.stereotype.Component;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import spring.beautiq.domain.auth.oauth2.dto.CustomOAuth2User;
 import spring.beautiq.domain.user.dto.UserDTO;
+import spring.beautiq.domain.user.entity.UserEntity;
+import spring.beautiq.domain.user.repository.UserRepository;
+import spring.beautiq.global.exception.GlobalErrorCode;
 
+@Component
+@RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-    private final JwtUtil jwtUtil;
+    private static final String AUTH_COOKIE = "Authorization";
+    private static final Set<String> PUBLIC_EXACT = Set.of("/", "/login", "/error");
+    private static final String[] PUBLIC_PREFIXES = {
+            "/oauth2/authorization", "/success", "/css", "/js", "/getpostman.com", "/auth", "/login/oauth2"
+    };
 
-    public JwtFilter(JwtUtil jwtUtil) {
-        this.jwtUtil = jwtUtil;
-    }
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
 
-        //cookie들을 불러온 뒤 Authorization key에 담긴 쿠키 찾기
+        String uri = request.getRequestURI();
+        String token = resolveToken(request);
+        boolean publicPath = isPublic(uri) || isPreflight(request);
 
-        String authorization = null;
+        if (token == null) {
+            if (publicPath) { chain.doFilter(request, response); return; }
+            writeError(response, GlobalErrorCode.INVALID_ACCESS_TOKEN); return;
+        }
+
+        GlobalErrorCode validation = validate(token);
+        if (validation != null) { // 실패
+            if (publicPath) { chain.doFilter(request, response); return; }
+            writeError(response, validation); return;
+        }
+
+        buildAuthentication(token).ifPresent(auth -> SecurityContextHolder.getContext().setAuthentication(auth));
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        return Arrays.stream(cookies)
+                .filter(c -> AUTH_COOKIE.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst().orElse(null);
+    }
 
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                System.out.println(cookie.getName());
-                if ("Authorization".equals(cookie.getName())) {
-                    authorization = cookie.getValue();
-                    break;
-                }
-            }
-        }
-
-
-        //Authorization 헤더 검증
-        if (authorization == null) {
-
-            System.out.println("token null");
-            filterChain.doFilter(request, response);
-
-            //조건이 해당되면 메소드 종료
-            return;
-        }
-
-        // 토큰
-        String token = authorization;
-        //토큰 소멸 시간 검증
+    private GlobalErrorCode validate(String token) {
         try {
-            if (jwtUtil.isExpired(token)) {
-               filterChain.doFilter(request, response);
-               return;
-            }
-        } catch (io.jsonwebtoken.JwtException | IllegalArgumentException e) {
-            // 잘못,변조된 토큰 -> 인증 미적용 후 다음 필터로 진행
-            filterChain.doFilter(request, response);
-            return;
+            if (jwtUtil.isExpired(token)) return GlobalErrorCode.INVALID_EXPIRED_JWT;
+            return null; // OK
+        } catch (Exception e) {
+            return GlobalErrorCode.INVALID_JWT; // 파싱/서명 실패
         }
+    }
 
+    private boolean isPreflight(HttpServletRequest req) { return "OPTIONS".equalsIgnoreCase(req.getMethod()); }
 
-        //토큰에서 username과 role 획득
-        String username= jwtUtil.getUsername(token);
-        String role = jwtUtil.getRole(token);
+    private boolean isPublic(String uri) {
+        if (uri == null) return false;
+        if (PUBLIC_EXACT.contains(uri)) return true;
+        for (String prefix : PUBLIC_PREFIXES) if (uri.startsWith(prefix)) return true;
+        return false;
+    }
 
-        //userDto를 생성하여 값 set
-        UserDTO userDTO = new UserDTO();
-        userDTO.setUsername(username);
-        userDTO.setRole(role);
+    private Optional<UsernamePasswordAuthenticationToken> buildAuthentication(String token) {
+        try {
+            String authKey = jwtUtil.getUsername(token);
+            String role = jwtUtil.getRole(token);
+            UserEntity user = userRepository.findByAuthKey(authKey);
+            UserDTO dto = UserDTO.from(user);
+            if (dto == null) { dto = new UserDTO(); dto.setAuthKey(authKey); dto.setRole(role); }
+            CustomOAuth2User principal = new CustomOAuth2User(dto);
+            return Optional.of(new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
 
-
-        //UserDetails에 회원 정보 객체 담기
-        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDTO);
-
-        //스프링 시큐리티 인증 토큰 생성
-        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User,
-                null,
-                java.util.List.of(new org.springframework.security.core.authority.SimpleGrantedAuthority(role)));
-
-        //세션에 사용자 등록
-        SecurityContextHolder.getContext().setAuthentication(authToken);
-
-        filterChain.doFilter(request, response);
+    private void writeError(HttpServletResponse response, GlobalErrorCode code) throws IOException {
+        response.setStatus(code.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        Instant now = Instant.now();
+        String body = '{' + "\"code\":\"" + code.name() + "\"," +
+                "\"message\":\"" + code.getMessage().replace("\"", "'") + "\"," +
+                "\"status\":" + code.getHttpStatus().value() + ',' +
+                "\"timestamp\":\"" + now + "\"}";
+        response.getWriter().write(body);
     }
 }

--- a/src/main/java/spring/beautiq/global/jwt/JwtUtil.java
+++ b/src/main/java/spring/beautiq/global/jwt/JwtUtil.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.security.Keys;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -32,8 +33,9 @@ public class JwtUtil {
 
     }
 
-    public String getUsername(String token) {
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("username", String.class);
+    public UUID getUserId(String token) {
+        String userId = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("userId", String.class);
+        return userId != null ? UUID.fromString(userId) : null;
     }
 
     public String getRole(String token) {
@@ -45,11 +47,11 @@ public class JwtUtil {
     }
 
 
-    public String createJwt(String username, String role, Long expiredMs) {
+    public String createJwt(UUID userId, String role, Long expiredMs) {
 
         Claims claims = Jwts.claims();
 
-        claims.put("username", username);
+        claims.put("userId", userId.toString());
         claims.put("role", role);
 
         return Jwts.builder()


### PR DESCRIPTION
# 작업내용
- ClassCastException 문제 해결
- authKey / username(닉네임) 분리
- 로그인 시 DB에 유저 추가되도록 구현
- 유저/인증 코드 리팩토링

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google OIDC 로그인 지원 추가 및 다중 소셜 계정 연동/이메일 기반 계정 병합 지원
  * JWT를 안전한 쿠키로 전달·검증해 로그인 상태가 더 안정적임
  * 로그인 성공 시 고정 성공 페이지로 리다이렉트
  * CORS 설정 통합으로 로컬 프론트엔드(및 지정 도메인) 접근 개선
  * OAuth2 관련 오류(미지원 제공자, 사용자 정보 조회 실패)에 대한 명확한 응답

* **Bug Fixes**
  * 인증 불필요한 공용 경로 정상 우회
  * 권한 기본값 및 인증 바인딩 처리 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->