### PR TITLE
hotfix: principalName empty

### DIFF
--- a/src/main/java/spring/beautiq/BeautiqApplication.java
+++ b/src/main/java/spring/beautiq/BeautiqApplication.java
@@ -2,6 +2,7 @@ package spring.beautiq;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
 public class BeautiqApplication {

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/config/SecurityConfig.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/config/SecurityConfig.java
@@ -10,7 +10,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -61,9 +63,21 @@ public class SecurityConfig {
 
 
                 .oauth2Login((oauth2) -> oauth2
-                        .userInfoEndpoint((userInfoEndpointConfig -> userInfoEndpointConfig
-                                .userService(customOAuth2UserService)))
-                        .successHandler(customSuccessHandler))
+                        .userInfoEndpoint((userInfoEndpointConfig -> {
+                            userInfoEndpointConfig
+                                    .userService(customOAuth2UserService);
+                            userInfoEndpointConfig
+                                    .oidcUserService(oidcUserRequest -> {
+                                        OidcUserService delegate = new OidcUserService();
+                                        OidcUser oidcUser = delegate.loadUser(oidcUserRequest);
+
+                                        customOAuth2UserService.loadUser(oidcUserRequest);
+
+                                        return oidcUser;
+                                    });
+                        }))
+                        .successHandler(customSuccessHandler)
+                )
 
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint((request, response, authException) -> {

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/dto/CustomOAuth2User.java
@@ -22,7 +22,6 @@ public class CustomOAuth2User implements OAuth2User {
         return Map.of(
                 "userId", userDTO.getUserId(),
                 "username", userDTO.getUsername(),
-                "name", userDTO.getName(),
                 "role", userDTO.getRole()
         );
     }
@@ -37,11 +36,13 @@ public class CustomOAuth2User implements OAuth2User {
         return userDTO.getUserId();
     }
 
+
+    //spring 내부 사용자 식별자
     @Override
     public String getName() {
-        return userDTO.getName();
+        return userDTO.getUsername();
     }
-
+    
     public String getUsername() {
         return userDTO.getUsername();
     }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/dto/CustomOAuth2User.java
@@ -42,7 +42,7 @@ public class CustomOAuth2User implements OAuth2User {
     public String getName() {
         return userDTO.getUsername();
     }
-    
+
     public String getUsername() {
         return userDTO.getUsername();
     }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/dto/KakaoResponse.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/dto/KakaoResponse.java
@@ -24,7 +24,11 @@ public class KakaoResponse implements OAuth2Response {
 
     @Override
     public String getEmail() {
-        return null;
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attribute.get("kakao_account");
+        if (kakaoAccount != null && kakaoAccount.containsKey("email")) {
+            return (String) kakaoAccount.get("email");
+        }
+        return "kakao_" + attribute.get("id") + "@kakao.local";
     }
 
     @Override

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOAuth2UserService.java
@@ -57,6 +57,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         return new CustomOAuth2User(userDTO);
     }
 
+
+
+
     private OAuth2Response createOAuth2Response(String registrationId, OAuth2User oAuth2User) {
         if (registrationId.equals("google")) {
             return new GoogleResponse(oAuth2User.getAttributes());

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOAuth2UserService.java
@@ -42,6 +42,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 .orElseGet(() -> {
                     UserEntity newUser = new UserEntity();
                     newUser.setUsername(username);
+
                     newUser.setEmail(oAuth2Response.getEmail());
                     newUser.setRole("ROLE_USER");
                     return userRepository.save(newUser);

--- a/src/main/java/spring/beautiq/domain/user/dto/OAuth2UserDTO.java
+++ b/src/main/java/spring/beautiq/domain/user/dto/OAuth2UserDTO.java
@@ -14,6 +14,5 @@ import lombok.Setter;
 public class OAuth2UserDTO {
     private String userId;
     private String username;
-    private String name;
     private String role;
 }

--- a/src/main/java/spring/beautiq/domain/user/dto/UserRequest.java
+++ b/src/main/java/spring/beautiq/domain/user/dto/UserRequest.java
@@ -2,7 +2,6 @@ package spring.beautiq.domain.user.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/spring/beautiq/domain/user/entity/UserEntity.java
+++ b/src/main/java/spring/beautiq/domain/user/entity/UserEntity.java
@@ -3,10 +3,12 @@ package spring.beautiq.domain.user.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import lombok.*;
 import spring.beautiq.global.base.BaseEntity;
 
 @Entity
+@Table(name = "user_entity")
 @Getter
 @Setter
 public class UserEntity extends BaseEntity {


### PR DESCRIPTION
로그인 시도 -> 사용자 정보(principal)가 비어 있음 오류 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - OIDC 연동 경로에 대한 사용자 로딩 흐름이 개선되어 다양한 OAuth2/OIDC 로그인을 더 안정적으로 처리합니다.
- 버그 수정
  - 카카오 로그인 시 이메일이 없을 때 대체 이메일을 생성해 계정 연동 실패 가능성을 줄였습니다.
- 리팩터
  - OAuth2 사용자 식별 기준을 ‘이름’에서 ‘사용자명(username)’으로 일관화했습니다.
  - 사용자 정보에서 중복되는 ‘이름’ 항목을 제거했습니다.
- 스타일
  - 공백 및 주석 정리로 코드 가독성 향상.
- 잡무(Chores)
  - 사용되지 않는 import 등 불필요한 정리 수행.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->