### PR TITLE
Feat/makeup: 이미지 처리 url 기반으로 수정

### DIFF
--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpController.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpController.java
@@ -54,12 +54,16 @@ public class MakeUpController {
             @ApiResponse(responseCode = "400", description = "잘못된 입력"),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
-    @PostMapping("/save")
+    @PostMapping(value = "/save", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> saveMakeUp(
             @Parameter(hidden = true) @CurrentUserId UUID userId,
-            @Valid @RequestBody MakeUpSaveRequestDto makeUpSaveRequestDto
+            @RequestPart(name = "imageName") String imageName,
+
+            @Valid @RequestPart(name = "data")
+            @Parameter(description = "키워드 (선택, 최대 5개)")
+            RecommendRequestDto recommendRequestDto
     ) {
-        makeUpService.saveMakeUp(userId, makeUpSaveRequestDto);
+        makeUpService.saveMakeUp(userId, new MakeUpSaveRequestDto(imageName, recommendRequestDto.getKeywords()));
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpController.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpController.java
@@ -75,7 +75,8 @@ public class MakeUpController {
                     1. 프론트에서 파일 업로드
                     2. 백엔드에서 Base64 변환하여 AI 서버 요청
                     3. AI 서버에서 3개 스타일 Base64로 응답
-                    4. 프론트는 Base64를 저장 (추후 시뮬레이션에 사용)
+                    4. 백엔드에서 Base64를 이미지로 변환 후 S3 임시 저장
+                    5. 백엔드에서 추천 이미지 이름 및 S3 URL 반환
                     
                     **S3 저장 없음** - 프론트 메모리에만 존재
                     """
@@ -86,6 +87,7 @@ public class MakeUpController {
     })
     @PostMapping(value = "/recommendation", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public RecommendResponseDto styleRecommend(
+            @CurrentUserId UUID userId,
             @RequestPart(name = "sourceImage")
             @Parameter(description = "사용자 얼굴 이미지 파일 (JPG/PNG)")
             MultipartFile sourceImage,
@@ -94,7 +96,7 @@ public class MakeUpController {
             @Parameter(description = "키워드 (선택, 최대 5개)")
             RecommendRequestDto recommendRequestDto
     ) throws IOException {
-        return makeUpService.styleRecommend(sourceImage, recommendRequestDto);
+        return makeUpService.styleRecommend(userId, sourceImage, recommendRequestDto);
     }
 
     /**

--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpController.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpController.java
@@ -82,7 +82,6 @@ public class MakeUpController {
                     4. 백엔드에서 Base64를 이미지로 변환 후 S3 임시 저장
                     5. 백엔드에서 추천 이미지 이름 및 S3 URL 반환
                     
-                    **S3 저장 없음** - 프론트 메모리에만 존재
                     """
     )
     @ApiResponses(value = {
@@ -136,9 +135,9 @@ public class MakeUpController {
                     시뮬레이션 결과 이미지(Base64)의 색상/강도를 조정한 결과를 Base64로 반환합니다.
                     
                     **흐름:**
-                    1. 프론트: 시뮬레이션 Base64 + 편집 조건
+                    1. 프론트: 시뮬레이션 이미지 이름 + 편집 조건
                     2. 백엔드: AI 서버에 커스터마이즈 요청
-                    3. 백엔드: 결과 Base64 반환
+                    3. 백엔드: 커스터마이징 된 이미지 이름, url 반환
                     4. (반복 가능)
                     
                     **편집 항목 설명:**
@@ -150,14 +149,18 @@ public class MakeUpController {
                       - "blush": 볼터치 intensity 조정
                     - intensity는 0~100 범위이며 기본값은 50입니다. 50보다 크면 메이크업이 더 진하게 적용되고, 50보다 작으면 더 연하게 적용됩니다.
                     
-                    **S3 저장 없음** - save API 호출 전까지 프론트 메모리에만 존재
                     """
     )
-    @PostMapping(value = "/customize", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/customize", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public CustomizeResponseDto customize(
-            @Valid @RequestBody CustomizeRequestDto customizeRequestDto
-    ) {
-        return makeUpService.customize(customizeRequestDto);
+            @CurrentUserId UUID userId,
+
+            @Schema(description = "시뮬레이션 된 이미지 이름", example = "temp/7f000001-9a6e-12b7-819a-6e42edf20000/fc32f75...", requiredMode = Schema.RequiredMode.REQUIRED)
+            @RequestPart("imageName") String imageName,
+
+            @RequestPart("data") CustomizeRequestDto customizeRequestDto
+    ) throws IOException {
+        return makeUpService.customize(imageName, customizeRequestDto, userId);
     }
 
 }

--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpController.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpController.java
@@ -105,23 +105,22 @@ public class MakeUpController {
     @Operation(
             summary = "메이크업 시뮬레이션",
             description = """
-                    원본 이미지(Base64)와 참조 스타일(파일 또는 Base64)을 받아 메이크업을 적용한 결과를 Base64로 반환합니다.
+                    원본 이미지와 참조 스타일(파일 또는 이미지 이름)을 받아 메이크업을 적용한 결과를 s3 url로 반환합니다.
 
                     **흐름:**
-                    1. 프론트: 원본 Base64 + (추천 이미지 Base64 선택 OR 새 파일 업로드)
+                    1. 프론트: 추천 이미지 이름 선택 OR 새 이미지 업로드
                     2. 백엔드: AI 서버에 시뮬레이션 요청
-                    3. 백엔드: 결과 Base64 반환
+                    3. 백엔드: 결과 이미지 s3 임시 저장
+                    4. 백엔드: 결과 이미지 이름 및 S3 URL 반환
 
-                    **S3 저장 없음** - 프론트 메모리에만 존재
                     """
     )
     @PostMapping(value = "/simulation", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ImageItem simulateMakeUp(
             @CurrentUserId UUID userId,
-            @RequestPart("sourceImage") MultipartFile sourceImage,
-            @RequestPart("styleImage") MultipartFile styleImage
+            @RequestPart("styleImage") String recommendImageName
     ) throws IOException {
-        return makeUpService.simulateMakeUp(userId, sourceImage, styleImage);
+        return makeUpService.simulateMakeUp(userId, recommendImageName);
     }
 
     /**

--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpController.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpController.java
@@ -40,13 +40,13 @@ public class MakeUpController {
                     시뮬레이션 또는 커스터마이징 결과 이미지(Base64)를 S3에 영구 저장하고 DB에 기록합니다.
                     
                     **흐름:**
-                    1. 프론트에서 Base64 이미지 전송
-                    2. 백엔드가 S3 images 폴더에 저장
+                    1. 프론트에서 이미지 url 전송
+                    2. 백엔드가 S3에 영구 저장
                     3. DB에 메이크업 기록 저장
                     
                     **요청:**
                     - Content-Type: application/json
-                    - imageBase64: Base64 인코딩된 이미지 문자열
+                    - imageName: 저장할 이미지 이름
                     """
     )
     @ApiResponses(value = {

--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
@@ -48,9 +48,10 @@ public class MakeUpService {
 
         String newImageName = s3Service.saveImage(saveRequestDto.getImageName(), userId);
 
+        String[] keywords = saveRequestDto.getKeywords();
         MakeUpEntity makeUp = MakeUpEntity.builder()
                 .user(userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found")))
-                .keywords(String.join(",", saveRequestDto.getKeywords()))
+                .keywords(keywords == null ? null : String.join(",", keywords))
                 .imageName(newImageName)
                 .build();
 

--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
@@ -45,27 +45,16 @@ public class MakeUpService {
      */
     @Transactional
     public void saveMakeUp(UUID userId, MakeUpSaveRequestDto saveRequestDto) {
-        String imageBase64 = saveRequestDto.getImageBase64();
 
-        if (imageBase64 == null || imageBase64.isBlank()) {
-            throw new IllegalArgumentException("Image Base64 is required");
-        }
+        String newImageName = s3Service.saveImage(saveRequestDto.getImageName(), userId);
 
-        try {
-            // Base64를 MultipartFile로 변환하여 S3에 저장
-            MultipartFile imageFile = base64ToMultipart(imageBase64);
-            String newImageName = s3Service.uploadImage(imageFile, userId, "");
+        MakeUpEntity makeUp = MakeUpEntity.builder()
+                .user(userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found")))
+                .keywords(String.join(",", saveRequestDto.getKeywords()))
+                .imageName(newImageName)
+                .build();
 
-            MakeUpEntity makeUp = MakeUpEntity.builder()
-                    .user(userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found")))
-                    .keywords(String.join(",", saveRequestDto.getKeywords()))
-                    .imageName(newImageName)
-                    .build();
-
-            makeUpRepository.save(makeUp);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to save image to S3", e);
-        }
+        makeUpRepository.save(makeUp);
     }
 
     /**

--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
@@ -252,21 +252,23 @@ public class MakeUpService {
      * @return 처리 상태와 결과 이미지(Base64)
      */
     public CustomizeResponseDto customize(
-            CustomizeRequestDto customizeRequestDto
-    ) {
+            String imageName,
+            CustomizeRequestDto customizeRequestDto,
+            UUID userId
+    ) throws IOException {
         // 입력 검증
-        if (customizeRequestDto == null || customizeRequestDto.getBaseImageBase64() == null || customizeRequestDto.getBaseImageBase64().isBlank()) {
-            return new CustomizeResponseDto("failed", null, "base_image_base64 is required");
+        if (customizeRequestDto == null || imageName == null || imageName.isBlank()) {
+            return new CustomizeResponseDto("failed", null, null, "imageName is required");
         }
         if (customizeRequestDto.getEdits() == null || customizeRequestDto.getEdits().isEmpty()) {
-            return new CustomizeResponseDto("failed", null, "edits is required and must contain at least one item");
+            return new CustomizeResponseDto("failed", null, null, "edits is required and must contain at least one item");
         }
 
-        String baseImage = extractBase64(customizeRequestDto.getBaseImageBase64());
+        String preImage = s3Service.imageNameToBase64(imageName);
 
         // 요청 DTO에 이미지, 편집 정보 담기
         CustomizeAiRequestDto customizeAiRequestDto = new CustomizeAiRequestDto();
-        customizeAiRequestDto.setBaseImageBase64(baseImage); // 현재 이미지
+        customizeAiRequestDto.setBaseImageBase64(preImage); // 현재 이미지
         for(CustomizeRequestDto.EditForWeb editForWeb : customizeRequestDto.getEdits()) {
             if(editForWeb.isEdited()) {
                 // intensity 범위는 DTO에서 검증되지만 방어적으로 보정
@@ -289,7 +291,7 @@ public class MakeUpService {
                 .block();
 
         if (customizeAiResponseDto == null) {
-            return new CustomizeResponseDto("failed", null, "AI service error: no response");
+            return new CustomizeResponseDto("failed", null, null, "AI service error: no response");
         }
 
         String status = customizeAiResponseDto.getStatus();
@@ -297,14 +299,17 @@ public class MakeUpService {
         String message = customizeAiResponseDto.getMessage();
 
         if (!"success".equalsIgnoreCase(status)) {
-            return new CustomizeResponseDto(status == null ? "failed" : status, null, message == null ? "AI processing failed" : message);
+            return new CustomizeResponseDto(status == null ? "failed" : status, null, null, message == null ? "AI processing failed" : message);
         }
 
         if (resultBase64 == null || resultBase64.isBlank()) {
-            return new CustomizeResponseDto("failed", null, "AI returned empty result image");
+            return new CustomizeResponseDto("failed", null, null, "AI returned empty result image");
         }
 
-        return new CustomizeResponseDto("success", resultBase64, null);
+        MultipartFile customizedImage = base64ToMultipart(resultBase64);
+        String customizedImageName = s3Service.uploadTempImage(customizedImage, userId);
+
+        return new CustomizeResponseDto("success", customizedImageName, s3Service.getPreSignedUrl(customizedImageName), null);
     }
 
 

--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
@@ -54,7 +54,7 @@ public class MakeUpService {
         try {
             // Base64를 MultipartFile로 변환하여 S3에 저장
             MultipartFile imageFile = base64ToMultipart(imageBase64);
-            String newImageName = s3Service.uploadImage(imageFile, userId);
+            String newImageName = s3Service.uploadImage(imageFile, userId, "");
 
             MakeUpEntity makeUp = MakeUpEntity.builder()
                     .user(userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found")))
@@ -187,11 +187,14 @@ public class MakeUpService {
             throw new IllegalStateException("AI service returned insufficient recommendations");
         }
 
+        // sourceImage 저장하기
+        s3Service.uploadSourceImage(sourceImage, userId);
+
         // Base64 응답 그대로 반환 (S3 저장하지 않음)
         RecommendResponseDto recommendResponseDto = new RecommendResponseDto();
         for (RecommendAiItem item : recommendAiResponseDto.getRecommendations()) {
             MultipartFile recommendImage = base64ToMultipart(item.getStyleImageBase64());// Base64 유효성 검증
-            String tempImageName = s3Service.uploadImage(recommendImage, userId);
+            String tempImageName = s3Service.uploadTempImage(recommendImage, userId);
             recommendResponseDto.addRecommendation(tempImageName, s3Service.getPreSignedUrl(tempImageName));
         }
 
@@ -204,38 +207,13 @@ public class MakeUpService {
      */
     public ImageItem simulateMakeUp(
             UUID userId,
-            MultipartFile sourceImage,
-            MultipartFile styleImage
+            String recommendImageName
             ) throws IOException {
-
-        // sourceImage 필수 검증
-        if (sourceImage == null || sourceImage.isEmpty()) {
-            throw new IllegalArgumentException("Source image is required");
-        }
-
-        String contentType = sourceImage.getContentType();
-        if (contentType == null || !contentType.startsWith("image/")) {
-            throw new IllegalArgumentException("Invalid source image file");
-        }
-
-        String sourceImageBase64 = multipartToBase64(sourceImage);
-        String styleImageBase64;
-
-        // styleImage 필수 검증
-        if (styleImage == null || styleImage.isEmpty()) {
-            throw new IllegalArgumentException("Style image is required");
-        }
-
-        String styleContentType = styleImage.getContentType();
-        if (styleContentType == null || !styleContentType.startsWith("image/")) {
-            throw new IllegalArgumentException("Invalid style image file");
-        }
-        styleImageBase64 = multipartToBase64(styleImage);
 
         // 요청 DTO에 이미지 담기
         SimulationAiRequestDto simulationAiRequestDto = SimulationAiRequestDto.builder()
-                .sourceImageBase64(sourceImageBase64)
-                .styleImageBase64(styleImageBase64)
+                .sourceImageBase64(s3Service.getSourceImgBase64(userId)) // 저장된 source 이미지 사용
+                .styleImageBase64(s3Service.imageNameToBase64(recommendImageName))
                 .build();
 
         // AI 서버에 JSON 요청
@@ -262,9 +240,11 @@ public class MakeUpService {
             throw new RuntimeException("AI service error: No result image");
         }
 
-        // Base64 응답 그대로 반환 (S3 저장하지 않음)
-        // ImageItem은 (imageName, imageUrl) 두 파라미터가 필요하므로 적절히 생성
-        return new ImageItem("simulated_makeup", simulationAiResponseDto.getResultImageBase64());
+        String SimulatedImageName = s3Service.uploadTempImage(
+                base64ToMultipart(simulationAiResponseDto.getResultImageBase64()),
+                userId
+        );
+        return new ImageItem(SimulatedImageName, s3Service.getPreSignedUrl(SimulatedImageName));
     }
 
     /**

--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
@@ -147,6 +147,7 @@ public class MakeUpService {
      * @return Base64 이미지 3개 (S3에 저장하지 않음)
      */
     public RecommendResponseDto styleRecommend(
+            UUID userId,
             MultipartFile sourceImage,
             RecommendRequestDto recommendRequestDto
     ) throws IOException {
@@ -189,8 +190,9 @@ public class MakeUpService {
         // Base64 응답 그대로 반환 (S3 저장하지 않음)
         RecommendResponseDto recommendResponseDto = new RecommendResponseDto();
         for (RecommendAiItem item : recommendAiResponseDto.getRecommendations()) {
-            // Base64 이미지를 그대로 반환
-            recommendResponseDto.addRecommendation(item.getStyleId(), item.getStyleImageBase64());
+            MultipartFile recommendImage = base64ToMultipart(item.getStyleImageBase64());// Base64 유효성 검증
+            String tempImageName = s3Service.uploadImage(recommendImage, userId);
+            recommendResponseDto.addRecommendation(tempImageName, s3Service.getPreSignedUrl(tempImageName));
         }
 
         return recommendResponseDto;

--- a/src/main/java/spring/beautiq/domain/makeup/dto/web/CustomizeRequestDto.java
+++ b/src/main/java/spring/beautiq/domain/makeup/dto/web/CustomizeRequestDto.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -21,7 +19,6 @@ import java.util.List;
 @Schema(description = "메이크업 커스터마이즈 요청 DTO",
         example = """
                 {
-                  "base_image_base64": "data:image/png;base64,/9j/4AAQSkZJRgABAQAAAQ...",
                   "edits": [
                     { "region": "lip", "intensity": 60 },
                     { "region": "skin", "intensity": 40 }
@@ -29,9 +26,9 @@ import java.util.List;
                 }
                 """)
 public class CustomizeRequestDto {
-    @NotBlank(message = "base_image_base64 is required")
-    @Schema(description = "원본 얼굴 이미지 (Base64 인코딩)", example = "/9j/4AAQSkZJRgABAQAAAQABAAD...", requiredMode = Schema.RequiredMode.REQUIRED)
-    private String baseImageBase64;
+//    @NotBlank(message = "imageName은 필수입니다")
+//    @Schema(description = "시뮬레이션 된 이미지 이름", example = "temp/7f000001-9a6e-12b7-819a-6e42edf20000/fc32f75...", requiredMode = Schema.RequiredMode.REQUIRED)
+//    private String imageName;
 
     @Valid
     @NotNull(message = "edits는 필수입니다")

--- a/src/main/java/spring/beautiq/domain/makeup/dto/web/CustomizeResponseDto.java
+++ b/src/main/java/spring/beautiq/domain/makeup/dto/web/CustomizeResponseDto.java
@@ -1,7 +1,6 @@
 package spring.beautiq.domain.makeup.dto.web;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -10,14 +9,16 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Schema(description = "메이크업 커스터마이즈 응답 DTO")
 public class CustomizeResponseDto {
     @Schema(description = "처리 상태 - success | failed", example = "success")
     private String status;
 
-    @Schema(description = "처리된 결과 이미지 (Base64) - 성공 시 존재", example = "/9j/4AAQSkZJRgABAQAAAQABAAD...")
-    private String resultImageBase64;
+    @Schema(description = "처리된 결과 이미지 이름 - 성공 시 존재", example = "temp/7f000001-9a6e-12b7-819a-6e42edf20000/fc32f75...")
+    private String imageName;
+
+    @Schema(description = "처리된 결과 이미지 url - 성공 시 존재", example = "https://beautiq-s3.s3.amazon...")
+    private String imageUrl;
 
     @Schema(description = "실패 시 에러 메시지", example = "Invalid edit parameters")
     private String message;

--- a/src/main/java/spring/beautiq/domain/makeup/dto/web/MakeUpSaveRequestDto.java
+++ b/src/main/java/spring/beautiq/domain/makeup/dto/web/MakeUpSaveRequestDto.java
@@ -7,9 +7,9 @@ import lombok.Data;
 @Data
 public class MakeUpSaveRequestDto {
 
-    @NotBlank(message = "Image Base64 is required")
-    @Schema(description = "Base64 인코딩된 이미지 문자열", required = true)
-    private String imageBase64;
+    @NotBlank(message = "Image Name cannot be blank")
+    @Schema(description = "저장할 시뮬레이션 이미지 이름", required = true)
+    private String imageName;
 
     @Schema(description = "키워드 배열")
     private String[] keywords;

--- a/src/main/java/spring/beautiq/domain/makeup/dto/web/MakeUpSaveRequestDto.java
+++ b/src/main/java/spring/beautiq/domain/makeup/dto/web/MakeUpSaveRequestDto.java
@@ -2,9 +2,11 @@ package spring.beautiq.domain.makeup.dto.web;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class MakeUpSaveRequestDto {
 
     @NotBlank(message = "Image Name cannot be blank")

--- a/src/main/java/spring/beautiq/domain/makeup/dto/web/RecommendResponseDto.java
+++ b/src/main/java/spring/beautiq/domain/makeup/dto/web/RecommendResponseDto.java
@@ -22,9 +22,9 @@ public class RecommendResponseDto {
     @Schema(description = "추천 스타일 항목")
     public static class RecommendItem {
         @Schema(description = "이미지 이름", example = "temp/7f000001-9a61-1a59-819a-61ba765e0603/85708e33...")
-        private String imageName;
+        private String recommendImageName;
 
         @Schema(description = "스타일 이미지 s3 url", example = "https://beautiq-s3.s3.amazonaws.com/temp/7f000001-9a61-1a59-819a-61ba765e0603/85708e33-838c-411d-89f0-df271c10ae5e.png?X-Am...")
-        private String imageUrl;
+        private String recommendImageUrl;
     }
 }

--- a/src/main/java/spring/beautiq/domain/makeup/dto/web/RecommendResponseDto.java
+++ b/src/main/java/spring/beautiq/domain/makeup/dto/web/RecommendResponseDto.java
@@ -13,18 +13,18 @@ public class RecommendResponseDto {
     @Schema(description = "추천 스타일 목록 (3개)")
     private List<RecommendItem> recommendations = new ArrayList<>();
 
-    public void addRecommendation(String styleId, String imageBase64) {
-        recommendations.add(new RecommendItem(styleId, imageBase64));
+    public void addRecommendation(String imageName, String imageUrl) {
+        recommendations.add(new RecommendItem(imageName, imageUrl));
     }
 
     @Data
     @AllArgsConstructor
     @Schema(description = "추천 스타일 항목")
     public static class RecommendItem {
-        @Schema(description = "스타일 ID", example = "아이유_009_face")
-        private String styleId;
+        @Schema(description = "이미지 이름", example = "temp/7f000001-9a61-1a59-819a-61ba765e0603/85708e33...")
+        private String imageName;
 
-        @Schema(description = "스타일 이미지 (Base64 인코딩)", example = "/9j/4AAQSkZJRgABAQAAAQABAAD...")
-        private String imageBase64;
+        @Schema(description = "스타일 이미지 s3 url", example = "https://beautiq-s3.s3.amazonaws.com/temp/7f000001-9a61-1a59-819a-61ba765e0603/85708e33-838c-411d-89f0-df271c10ae5e.png?X-Am...")
+        private String imageUrl;
     }
 }

--- a/src/main/java/spring/beautiq/domain/makeup/s3/S3Service.java
+++ b/src/main/java/spring/beautiq/domain/makeup/s3/S3Service.java
@@ -79,7 +79,7 @@ public class S3Service {
                 ? originalImageName.substring(originalImageName.lastIndexOf("."))
                 : "";
 
-        // temp/{userId}/ 폴더에 저장. 이미지 소유권 기록
+        // temp/{userId}/ 폴더에 저장. 이미지 소유권 기록. png로 통일
         String imageName = fileName + ".png";
 
         ObjectMetadata metadata = new ObjectMetadata();

--- a/src/main/java/spring/beautiq/domain/makeup/s3/S3Service.java
+++ b/src/main/java/spring/beautiq/domain/makeup/s3/S3Service.java
@@ -41,10 +41,28 @@ public class S3Service {
         }
     }
 
+    public void uploadSourceImage(MultipartFile sourceImage, UUID userId) throws IOException {
+
+        String fileName = "sourceImg/" + userId;
+        uploadImage(sourceImage, userId, fileName);
+    }
+
+    public String uploadTempImage(MultipartFile recommendImage, UUID userId) throws IOException {
+
+        String fileName = "temp/" + userId + "/" + UUID.randomUUID();
+        return uploadImage(recommendImage, userId, fileName);
+
+    }
+
     /**
-     * S3에 이미지 임시 업로드 하기
+     * S3에 프로필 업로드 하기
      */
     public String uploadImage(MultipartFile image, UUID userId) throws IOException {
+        String fileName = "profile/" + userId;
+        return uploadImage(image, userId, fileName);
+    }
+
+    public String uploadImage(MultipartFile image, UUID userId, String fileName) throws IOException {
         ensureEnabled();
         // 이미지 입력 유효 검증
         if (image == null || image.isEmpty()) {
@@ -62,7 +80,7 @@ public class S3Service {
                 : "";
 
         // temp/{userId}/ 폴더에 저장. 이미지 소유권 기록
-        String imageName = "temp/" + userId + "/" + UUID.randomUUID() + extension;
+        String imageName = fileName + extension;
 
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentType(image.getContentType());
@@ -160,4 +178,15 @@ public class S3Service {
         }
         amazonS3.deleteObject(bucket, imageName);
     }
+
+    public String getSourceImgBase64(UUID userId) {
+        String fileName = "sourceImg/" + userId + ".png";
+        try {
+            return imageNameToBase64(fileName);
+        } catch (IOException e) {
+            log.error("Failed to get source image from S3 for user {}: {}", userId, e.getMessage());
+            return null;
+        }
+    }
+
 }

--- a/src/main/java/spring/beautiq/domain/makeup/s3/S3Service.java
+++ b/src/main/java/spring/beautiq/domain/makeup/s3/S3Service.java
@@ -185,7 +185,7 @@ public class S3Service {
             return imageNameToBase64(fileName);
         } catch (IOException e) {
             log.error("Failed to get source image from S3 for user {}: {}", userId, e.getMessage());
-            return null;
+            throw new IllegalStateException("Source image not found for user: " + userId, e);
         }
     }
 

--- a/src/main/java/spring/beautiq/domain/makeup/s3/S3Service.java
+++ b/src/main/java/spring/beautiq/domain/makeup/s3/S3Service.java
@@ -80,7 +80,7 @@ public class S3Service {
                 : "";
 
         // temp/{userId}/ 폴더에 저장. 이미지 소유권 기록
-        String imageName = fileName + extension;
+        String imageName = fileName + ".png";
 
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentType(image.getContentType());


### PR DESCRIPTION
base64로 처리되고 있던 메이크업에서의 이미지 전송 부분 url 기반으로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 이미지 전송을 Base64에서 multipart/form-data로 전환 및 API 시그니처 정비
  * 이미지 저장/처리 흐름을 로컬/Base64에서 S3 기반 키·URL 반환으로 변경

* **New Features**
  * 여러 엔드포인트에서 userId 수신으로 사용자별 이미지 저장/조회 지원
  * 시뮬레이션·커스터마이즈 결과를 임시 S3 이미지 이름(imageName)과 프리사인드 URL(imageUrl)로 제공

* **API / DTO 변경**
  * 요청·응답 DTO에서 Base64 필드 제거 및 imageName/imageUrl 필드로 대체
<!-- end of auto-generated comment: release notes by coderabbit.ai -->