### PR TITLE
fix: update oauth redirect

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,7 +19,7 @@ app:
     redirect: ${OAUTH_REDIRECT:http://localhost:5173/oauth/callback}
     cookie-domain: ${COOKIE_DOMAIN:}
     use-cookie-secure: ${COOKIE_SECURE:false}
-    allowed-origin: ${FRONTEND_ORIGIN:http://localhost:3000}
+    allowed-origin: ${FRONTEND_ORIGIN:http://localhost:5173}
   auth:
     dev-login-page-enabled: ${DEV_LOGIN_PAGE_ENABLED:true}
   ai-server:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,7 +16,7 @@ app:
   openapi:
     enabled: ${SWAGGER_ENABLED:true}
   oauth2:
-    redirect: ${OAUTH_REDIRECT:http://localhost:3000/oauth/callback}
+    redirect: ${OAUTH_REDIRECT:http://localhost:5173/oauth/callback}
     cookie-domain: ${COOKIE_DOMAIN:}
     use-cookie-secure: ${COOKIE_SECURE:false}
     allowed-origin: ${FRONTEND_ORIGIN:http://localhost:3000}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,7 +75,7 @@ app:
     redirect: ${OAUTH_REDIRECT}
     cookie-domain: ${COOKIE_DOMAIN}
     use-cookie-secure: ${COOKIE_SECURE}
-    allowed-origin: ${FRONTEND_ORIGIN:http://localhost:3000}
+    allowed-origin: ${FRONTEND_ORIGIN:http://localhost:5173}
   ai-server:
     url: ${AI_SERVER_URL}
     connect-timeout-ms: 10000


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * OAuth2 리디렉션 URL 및 CORS 허용 출처 기본값을 http://localhost:5173으로 업데이트했습니다 (기존 http://localhost:3000에서 변경).
  * 동작, 오류 처리 또는 공개 API에는 영향이 없으며 구성 기본값만 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->