### PR TITLE
fix: 버셀용 도메인 추가

### DIFF
--- a/src/main/java/spring/beautiq/global/config/WebConfig.java
+++ b/src/main/java/spring/beautiq/global/config/WebConfig.java
@@ -26,7 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns(allowedOrigin, "http://localhost:*", "http://127.0.0.1:*")  // 프론트 도메인 + localhost 허용
+                .allowedOriginPatterns(allowedOrigin, "http://localhost:*", "http://127.0.0.1:*", " https://www.beautuq.my:*")  // 프론트 도메인 + localhost + 버셀 도메인 허용
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/spring/beautiq/global/config/WebConfig.java
+++ b/src/main/java/spring/beautiq/global/config/WebConfig.java
@@ -26,7 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns(allowedOrigin, "http://localhost:*", "http://127.0.0.1:*", " https://www.beautuq.my:*")  // 프론트 도메인 + localhost + 버셀 도메인 허용
+                .allowedOriginPatterns(allowedOrigin, "http://localhost:*", "http://127.0.0.1:*", "https://www.beautiq.my:*")  // 프론트 도메인 + localhost + 버셀 도메인 허용
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * API의 CORS 허용 도메인에 새 항목을 추가했습니다. 이제 https://www.beautiq.my(포트 와일드카드 포함)에서의 접근이 허용되어, 해당 도메인에서 API를 안전하게 호출할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->