### PR TITLE
feat:profile image,provider fields to OAuth2 user

### DIFF
--- a/src/main/java/spring/beautiq/domain/auth/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/dto/CustomOAuth2User.java
@@ -34,6 +34,17 @@ public class CustomOAuth2User implements OAuth2User {
             attributes.put("role", userDTO.getRole());
         }
 
+        // ===== 아래 3개 추가 =====
+        if (userDTO.getEmail() != null) {
+            attributes.put("email", userDTO.getEmail());
+        }
+        if (userDTO.getProfileImage() != null) {
+            attributes.put("profileImage", userDTO.getProfileImage());
+        }
+        if (userDTO.getProvider() != null) {
+            attributes.put("provider", userDTO.getProvider());
+        }
+
         return attributes.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(attributes);
     }
 
@@ -57,6 +68,20 @@ public class CustomOAuth2User implements OAuth2User {
 
     public String getUsername() {
         return userDTO.getUsername();
+    }
+
+
+
+    public String getEmail() {
+        return userDTO.getEmail();
+    }
+
+    public String getProfileImage() {
+        return userDTO.getProfileImage();
+    }
+
+    public String getProvider() {
+        return userDTO.getProvider();
     }
 
 }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/dto/GoogleResponse.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/dto/GoogleResponse.java
@@ -31,4 +31,9 @@ public class GoogleResponse implements OAuth2Response {
     public String getName() {
         return (String) attribute.get("name");
     }
+
+    @Override
+    public String getProfileImage() {
+        return "";
+    }
 }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/dto/GoogleResponse.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/dto/GoogleResponse.java
@@ -34,6 +34,8 @@ public class GoogleResponse implements OAuth2Response {
 
     @Override
     public String getProfileImage() {
-        return "";
+        Object picture = attribute.get("picture");
+        return picture != null ? picture.toString() : null;
+
     }
 }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/dto/KakaoResponse.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/dto/KakaoResponse.java
@@ -42,4 +42,9 @@ public class KakaoResponse implements OAuth2Response {
         }
         return null;
     }
+
+    @Override
+    public String getProfileImage() {
+        return "";
+    }
 }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/dto/KakaoResponse.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/dto/KakaoResponse.java
@@ -45,6 +45,13 @@ public class KakaoResponse implements OAuth2Response {
 
     @Override
     public String getProfileImage() {
-        return "";
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attribute.get("kakao_account");
+        if (kakaoAccount != null) {
+            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+            if (profile != null && profile.containsKey("profile_image_url")) {
+                return (String) profile.get("profile_image_url");
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/dto/OAuth2Response.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/dto/OAuth2Response.java
@@ -12,5 +12,8 @@ public interface OAuth2Response {
 
     String getName();
 
+    String getProfileImage(); // 이거 추가
+
+
 
 }

--- a/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOAuth2UserService.java
@@ -39,6 +39,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String providerId = oAuth2Response.getProvider() + "_" + oAuth2Response.getProviderId();
         String email = oAuth2Response.getEmail();
+        String profileImage = oAuth2Response.getProfileImage(); // 프로필 이미지 가져오기
 
         // providerId로 먼저 조회 (이메일 변경 케이스 대응)
         UserEntity userEntity = userRepository.findByProviderId(providerId)
@@ -48,6 +49,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                             .map(existing -> {
                                 // 이메일로 찾았지만 providerId가 없는 경우 업데이트
                                 existing.setProviderId(providerId);
+                                existing.setProfileImage(profileImage); // 프로필 이미지 업데이트
                                 return userRepository.save(existing);
                             })
                             .orElseGet(() -> {
@@ -57,14 +59,24 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                                 newUser.setEmail(email);
                                 newUser.setUsername(generateDefaultUsername(email));
                                 newUser.setRole("ROLE_USER");
+                                newUser.setProfileImage(profileImage); // 프로필 이미지 저장
                                 return userRepository.save(newUser);
                             });
                 });
+
+        // providerId에서 provider 추출 (kakao_123456 -> kakao)
+        String provider = null;
+        if (providerId != null && providerId.contains("_")) {
+            provider = providerId.split("_")[0];
+        }
 
         OAuth2UserDTO userDTO = OAuth2UserDTO.builder()
                 .userId(userEntity.getId().toString())
                 .username(userEntity.getUsername())
                 .role(userEntity.getRole())
+                .email(userEntity.getEmail())              // 추가
+                .profileImage(userEntity.getProfileImage()) // 추가
+                .provider(provider)                         // 추가
                 .build();
 
         return new CustomOAuth2User(userDTO);

--- a/src/main/java/spring/beautiq/domain/user/dto/OAuth2UserDTO.java
+++ b/src/main/java/spring/beautiq/domain/user/dto/OAuth2UserDTO.java
@@ -22,4 +22,14 @@ public class OAuth2UserDTO {
 
     @Schema(description = "사용자 역할", example = "ROLE_USER")
     private String role;
+
+    @Schema(description = "이메일", example = "minwoo@example.com")
+    private String email;
+
+    @Schema(description = "프로필 이미지 URL")
+    private String profileImage;
+
+    @Schema(description = "OAuth 제공자", example = "kakao")
+    private String provider;
+
 }

--- a/src/main/java/spring/beautiq/domain/user/entity/UserEntity.java
+++ b/src/main/java/spring/beautiq/domain/user/entity/UserEntity.java
@@ -20,9 +20,10 @@ public class UserEntity extends BaseEntity {
     private String username;
 
     @Column(unique = true)
-    private String providerId; // google_123456, kakao_789012 등 OAuth provider의 고유 ID
+    private String providerId; // google_123456, kakao_789012
 
     private String role;
+
     @Column(length = 2048)
     private String profileImage;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * OAuth 소셜 로그인 시 프로필 이미지 자동 저장 및 조회 기능 추가
  * 사용자 정보에 이메일 및 OAuth 제공자 정보 포함
  * Google 및 Kakao 로그인에서 프로필 이미지 지원 확대, 제공자 식별 정보 노출 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->