### PR TITLE
fix:오류수정:Set username during OAuth2 user creation and update

### DIFF
--- a/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/spring/beautiq/domain/auth/oauth2/service/CustomOAuth2UserService.java
@@ -58,6 +58,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                                 // 이메일로 찾았지만 providerId가 없는 경우 업데이트
                                 existing.setProviderId(providerId);
                                 existing.setProfileImage(profileImage); // 프로필 이미지 업데이트
+                                // username이 없으면 설정
+                                if (existing.getUsername() == null || existing.getUsername().isEmpty()) {
+                                    existing.setUsername(name != null && !name.isEmpty()
+                                            ? name
+                                            : generateDefaultUsername(email));
+                                }
                                 return userRepository.save(existing);
                             })
                             .orElseGet(() -> {
@@ -65,6 +71,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                                 UserEntity newUser = new UserEntity();
                                 newUser.setProviderId(providerId);
                                 newUser.setEmail(email);
+                                newUser.setUsername(name != null && !name.isEmpty()
+                                        ? name
+                                        : generateDefaultUsername(email));
                                 newUser.setRole("ROLE_USER");
                                 newUser.setProfileImage(profileImage); // 프로필 이미지 저장
                                 return userRepository.save(newUser);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* OAuth2 계정 생성 시 사용자 이름이 올바르게 설정됩니다.
* 기존 계정에 누락된 사용자 이름이 자동으로 설정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->