### PR TITLE
fix: 시간대 설정

### DIFF
--- a/src/main/java/spring/beautiq/global/base/BaseEntity.java
+++ b/src/main/java/spring/beautiq/global/base/BaseEntity.java
@@ -15,6 +15,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -36,10 +38,12 @@ public abstract class BaseEntity {
     @Column(nullable = false, updatable = false)
     @NotNull
     @CreatedDate
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     LocalDateTime createdAt;
 
     @Column(nullable = false)
     @NotNull
     @LastModifiedDate
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     LocalDateTime updatedAt;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선사항

* **날짜 및 시간 형식 표준화**
  * API 응답의 타임스탬프 필드가 표준 형식으로 일관되게 표시되도록 개선되었습니다. 모든 시간 정보는 서울 시간대 기준으로 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->