### PR TITLE
fix: customize edits 값 dto에 저장 안되던 문제 해결

### DIFF
--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
@@ -1,5 +1,7 @@
 package spring.beautiq.domain.makeup;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +41,16 @@ public class MakeUpService {
     private final WebClient.Builder webClientBuilder;
 
     private final S3Service s3Service;
+    private final ObjectMapper objectMapper; // JSON 직렬화용
+
+    // JSON 직렬화 헬퍼 (메서드명 변경: safeJson)
+    private String safeJson(Object obj) {
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+        } catch (Exception e) {
+            return "{\"error\":\"serialize failed: " + e.getMessage() + "\"}";
+        }
+    }
 
     /**
      * 메이크업 저장 - Base64 이미지를 S3에 저장하고 DB에 기록
@@ -250,16 +262,6 @@ public class MakeUpService {
         return new ImageItem(SimulatedImageName, s3Service.getPreSignedUrl(SimulatedImageName));
     }
 
-    /**
-     * Base64 data URI에서 순수 Base64 추출
-     */
-    private String extractBase64(String base64Data) {
-        if (base64Data.startsWith("data:image")) {
-            String[] parts = base64Data.split(",");
-            return parts.length > 1 ? parts[1] : parts[0];
-        }
-        return base64Data;
-    }
 
     /**
      * 메이크업 커스터마이즈
@@ -270,6 +272,7 @@ public class MakeUpService {
             CustomizeRequestDto customizeRequestDto,
             UUID userId
     ) throws IOException {
+        log.info("[CUSTOMIZE] start imageName={} editsCount={} userId={}", imageName, customizeRequestDto == null ? -1 : (customizeRequestDto.getEdits() == null ? -1 : customizeRequestDto.getEdits().size()), userId);
         // 입력 검증
         if (customizeRequestDto == null || imageName == null || imageName.isBlank()) {
             return new CustomizeResponseDto("failed", null, null, "imageName is required");
@@ -282,16 +285,33 @@ public class MakeUpService {
 
         // 요청 DTO에 이미지, 편집 정보 담기
         CustomizeAiRequestDto customizeAiRequestDto = new CustomizeAiRequestDto();
-        customizeAiRequestDto.setBaseImageBase64(preImage); // 현재 이미지
+        customizeAiRequestDto.setBaseImageBase64(preImage);
         for(CustomizeRequestDto.EditForWeb editForWeb : customizeRequestDto.getEdits()) {
-            if(editForWeb.isEdited()) {
-                // intensity 범위는 DTO에서 검증되지만 방어적으로 보정
+            Boolean editedFlag = editForWeb.getEdited();
+            boolean apply = (editedFlag == null) || Boolean.TRUE.equals(editedFlag); // null 또는 true면 적용
+            if(apply) {
                 int intensity = Math.max(0, Math.min(100, editForWeb.getIntensity()));
-                customizeAiRequestDto.addEdit(
-                        editForWeb.getRegion(),
-                        intensity
-                );
+                String region = editForWeb.getRegion();
+                if("eye".equalsIgnoreCase(region)) { // AI 패턴에 맞게 매핑
+                    region = "eyelid";
+                }
+                customizeAiRequestDto.addEdit(region, intensity);
             }
+        }
+        if (log.isDebugEnabled()) {
+            String editsJson = safeJson(customizeAiRequestDto.getEdits());
+            log.debug("""
+================ [AI CUSTOMIZE REQUEST] ================
+imageName: {}
+baseImageBase64:
+  length: {}
+  head(120): {}
+edits ({} items) JSON:
+{}
+=======================================================
+""", imageName, customizeAiRequestDto.getBaseImageBase64().length(), head(customizeAiRequestDto.getBaseImageBase64(), 120), customizeAiRequestDto.getEdits().size(), editsJson);
+        } else {
+            log.info("[CUSTOMIZE] baseImage len={} editsApplied={}", preImage.length(), customizeAiRequestDto.getEdits().size());
         }
 
         // AI 서버에 JSON 요청
@@ -305,7 +325,24 @@ public class MakeUpService {
                 .block();
 
         if (customizeAiResponseDto == null) {
+            log.warn("[CUSTOMIZE] AI response null imageName={}", imageName);
             return new CustomizeResponseDto("failed", null, null, "AI service error: no response");
+        }
+
+        if (log.isDebugEnabled()) { // 이전에 null 반환했으므로 추가 null 체크 불필요
+            String result = customizeAiResponseDto.getResultImageBase64();
+            int len = result == null ? 0 : result.length();
+            log.debug("""
+================ [AI CUSTOMIZE RESPONSE] ================
+status: {}
+message: {}
+resultImageBase64:
+  length: {}
+  head(120): {}
+========================================================
+""", customizeAiResponseDto.getStatus(), customizeAiResponseDto.getMessage(), len, result == null ? "null" : head(result, 120));
+        } else {
+            log.info("[CUSTOMIZE] result status={} resultBase64Len={}", customizeAiResponseDto.getStatus(), customizeAiResponseDto.getResultImageBase64() == null ? 0 : customizeAiResponseDto.getResultImageBase64().length());
         }
 
         String status = customizeAiResponseDto.getStatus();
@@ -324,6 +361,11 @@ public class MakeUpService {
         String customizedImageName = s3Service.uploadTempImage(customizedImage, userId);
 
         return new CustomizeResponseDto("success", customizedImageName, s3Service.getPreSignedUrl(customizedImageName), null);
+    }
+
+    private String head(String base64, int limit) {
+        if (base64 == null) return "null";
+        return base64.length() <= limit ? base64 : base64.substring(0, limit) + "...";
     }
 
 

--- a/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
+++ b/src/main/java/spring/beautiq/domain/makeup/MakeUpService.java
@@ -1,7 +1,6 @@
 package spring.beautiq.domain.makeup;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -287,7 +286,7 @@ public class MakeUpService {
         CustomizeAiRequestDto customizeAiRequestDto = new CustomizeAiRequestDto();
         customizeAiRequestDto.setBaseImageBase64(preImage);
         for(CustomizeRequestDto.EditForWeb editForWeb : customizeRequestDto.getEdits()) {
-            Boolean editedFlag = editForWeb.getEdited();
+            Boolean editedFlag = editForWeb.getIsEdited();
             boolean apply = (editedFlag == null) || Boolean.TRUE.equals(editedFlag); // null 또는 true면 적용
             if(apply) {
                 int intensity = Math.max(0, Math.min(100, editForWeb.getIntensity()));

--- a/src/main/java/spring/beautiq/domain/makeup/dto/web/CustomizeRequestDto.java
+++ b/src/main/java/spring/beautiq/domain/makeup/dto/web/CustomizeRequestDto.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -41,11 +40,11 @@ public class CustomizeRequestDto {
     @Schema(description = "편집 항목")
     public static class EditForWeb {
         // 클라이언트가 is_edited(혹은 edited) 값을 보내지 않으면 null -> 서버에서 기본 true로 처리
-        private Boolean edited; // optional; null=implicit true
+        private Boolean isEdited; // optional; null=implicit true
         private String region; // "skin" | "eye" | "lip" | "blush"
         private int intensity; // 0~100
 
-        public Boolean getEdited() { return edited; }
+        public Boolean getIsEdited() { return isEdited; }
 //        public void setEdited(Boolean edited) { this.edited = edited; }
     }
 }

--- a/src/main/java/spring/beautiq/domain/makeup/dto/web/CustomizeRequestDto.java
+++ b/src/main/java/spring/beautiq/domain/makeup/dto/web/CustomizeRequestDto.java
@@ -40,8 +40,12 @@ public class CustomizeRequestDto {
     @AllArgsConstructor
     @Schema(description = "편집 항목")
     public static class EditForWeb {
-        private boolean isEdited;
+        // 클라이언트가 is_edited(혹은 edited) 값을 보내지 않으면 null -> 서버에서 기본 true로 처리
+        private Boolean edited; // optional; null=implicit true
         private String region; // "skin" | "eye" | "lip" | "blush"
         private int intensity; // 0~100
+
+        public Boolean getEdited() { return edited; }
+//        public void setEdited(Boolean edited) { this.edited = edited; }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -156,6 +156,9 @@ aws:
 # AWS SDK 로그 레벨 조정, 임시 조치이므로 25년도 내로 v2로 마이그레이션 필수
 logging:
   level:
+    root: INFO
     com.amazonaws: ERROR
     software.amazon.awssdk: ERROR
     com.amazonaws.util: ERROR
+    spring.beautiq: DEBUG
+    spring.beautiq.domain.makeup: DEBUG


### PR DESCRIPTION
기존에 로직에서 edits 값이 dto에 제대로 매핑이 되지 않아 customize가 진행이 되지 않았음. edits가 제대로 들어가는지 로깅하는 내용과 매핑 제대로 하도록 로직 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **개선사항**
  * 메이크업 커스터마이징의 안정성 및 예외 처리 강화 — AI 응답이 없을 때 안전하게 실패 처리하고 상세 로그 제공
  * 편집 적용 로직 개선으로 일부 영역 매핑과 null/암시적 true 처리 향상
  * 로그 가시성 향상 — 요청/응답에 대한 디버그·요약 로그 및 베이스64 미리보기 추가
  * 설정 변경으로 관련 패키지의 디버그 로그가 더 자세히 기록됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->